### PR TITLE
Remove hard coded URL

### DIFF
--- a/docs/neo4j-graphql-js-middleware-authorization.md
+++ b/docs/neo4j-graphql-js-middleware-authorization.md
@@ -214,7 +214,7 @@ const resolvers = {
 };
 ```
 
-This resolver object can then be attached to the GraphQL schema using [`makeAugmentedSchema`](http://localhost:3000/docs/neo4j-graphql-js-api.html#makeaugmentedschemaoptions-graphqlschema)
+This resolver object can then be attached to the GraphQL schema using [`makeAugmentedSchema`](neo4j-graphql-js-api.html#makeaugmentedschemaoptions-graphqlschema)
 
 We can apply this same strategy to check for user scopes, inspect scopes on a JWT, etc.
 


### PR DESCRIPTION
The link on [GraphQL Authorization And Middleware's Inspect Context In Resolver
 section](https://grandstack.io/docs/neo4j-graphql-js-middleware-authorization.html#inspect-context-in-resolver) has a hard coded URL (http://localhost:3000/docs/).