### PR TITLE
Update neo4j-graphql-js-quickstart.md

### DIFF
--- a/docs/neo4j-graphql-js-quickstart.md
+++ b/docs/neo4j-graphql-js-quickstart.md
@@ -44,7 +44,7 @@ const schema = makeAugmentedSchema({ typeDefs });
 Create a neo4j-javascript-driver instance:
 
 ```
-import { v1 as neo4j } from 'neo4j-driver';
+import neo4j from 'neo4j-driver';
 
 const driver = neo4j.driver(
   'bolt://localhost:7687',


### PR DESCRIPTION
Update the import of `neo4j-driver` on the current version as listed [here](https://www.npmjs.com/package/neo4j-driver#breaking-changes)

> Driver API is moved from neo4j.v1 to neo4j namespace.
