### PR TITLE
Expressing names for source and target node type fields on relationship types

### DIFF
--- a/website/docs/graphql-relationship-types.mdx
+++ b/website/docs/graphql-relationship-types.mdx
@@ -107,8 +107,7 @@ Here we query for a user and their movie ratings, selecting the `rating` and `cr
 
 ## Field names for related nodes
 
-There are two valid ways to express which fields of a `@relation` type refer to its [source and target node](https://neo4j.com/docs/getting-started/current/graphdb-concepts/#graphdb-relationship-types) types. The `Rated` relationship type above defines `from` and `to` fields..<br>
-Once semantically clear names have been decided for source and target node fields, then those field names can be provided to the `from` and `to` arguments of the `@relation` type directive.
+There are two valid ways to express which fields of a `@relation` type refer to its [source and target node](https://neo4j.com/docs/getting-started/current/graphdb-concepts/#graphdb-relationship-types) types. The `Rated` relationship type above defines `from` and `to` fields. More semantic names can be provided for the source and target node fields to the `from` and `to` arguments of the `@relation` type directive.
 
 ```graphql
 type Rated @relation(name: "RATED", from: "user", to: "movie") {

--- a/website/docs/graphql-relationship-types.mdx
+++ b/website/docs/graphql-relationship-types.mdx
@@ -105,6 +105,33 @@ Here we query for a user and their movie ratings, selecting the `rating` and `cr
 }`} />
 </div>
 
+## Field names for related nodes
+
+There are two valid ways to express which fields of a `@relation` type refer to its [source and target node](https://neo4j.com/docs/getting-started/current/graphdb-concepts/#graphdb-relationship-types) types. The `Rated` relationship type above defines `from` and `to` fields..<br>
+Once semantically clear names have been decided for source and target node fields, then those field names can be provided to the `from` and `to` arguments of the `@relation` type directive.
+
+```graphql
+type Rated @relation(name: "RATED", from: "user", to: "movie") {
+  user: User
+  movie: Movie
+  rating: Float
+  created: DateTime
+}
+```
+
+## Default relationship name
+
+If the `name` argument of the `@relation` type directive is not provided, then its default is generated during schema augmentation to be the conversion of the type name to Snake case.
+
+```graphql
+type UserRated @relation(from: "user", to: "movie") { # name: "USER_RATED"
+  user: User
+  movie: Movie
+  rating: Float
+  created: DateTime
+}
+```
+
 ## Relationship mutations
 
 See the [generated mutations](graphql-schema-generation-augmentation.mdx#generated-mutations) section for information on the mutations generated for relationship types.

--- a/website/docs/graphql-relationship-types.mdx
+++ b/website/docs/graphql-relationship-types.mdx
@@ -107,7 +107,7 @@ Here we query for a user and their movie ratings, selecting the `rating` and `cr
 
 ## Field names for related nodes
 
-There are two valid ways to express which fields of a `@relation` type refer to its [source and target node](https://neo4j.com/docs/getting-started/current/graphdb-concepts/#graphdb-relationship-types) types. The `Rated` relationship type above defines `from` and `to` fields. More semantic names can be provided for the source and target node fields to the `from` and `to` arguments of the `@relation` type directive.
+There are two valid ways to express which fields of a `@relation` type refer to its [source and target node](https://neo4j.com/docs/getting-started/current/graphdb-concepts/#graphdb-relationship-types) types. The `Rated` relationship type above defines `from` and `to` fields. Semantically specific names can be provided for the source and target node fields to the `from` and `to` arguments of the `@relation` type directive.
 
 ```graphql
 type Rated @relation(name: "RATED", from: "user", to: "movie") {


### PR DESCRIPTION
This adds a bit of docs to show that the names of the source and target node type fields on relationship types can be expressed using the recently added `from` and `to` arguments of the `@relation` type directive. See: https://github.com/neo4j-graphql/neo4j-graphql-js/pull/521